### PR TITLE
Address YANG doctor reviews; change prefix

### DIFF
--- a/draft/draft-ietf-bfd-optimizing-authentication.xml
+++ b/draft/draft-ietf-bfd-optimizing-authentication.xml
@@ -597,7 +597,7 @@ XML: N/A, the requested URI is an XML namespace.
 	      <![CDATA[
 name:         ietf-bfd-opt-auth
 namespace:    urn:ietf:params:xml:ns:yang:ietf-bfd-opt-auth
-prefix:       bfdoa
+prefix:       bfd-oa
 reference:    RFC XXXX
 	      ]]>
 	    </artwork>

--- a/src/yang/ietf-bfd-opt-auth.yang
+++ b/src/yang/ietf-bfd-opt-auth.yang
@@ -1,7 +1,7 @@
 module ietf-bfd-opt-auth {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-bfd-opt-auth";
-  prefix "bfdoa";
+  prefix "bfd-oa";
 
   import ietf-routing {
     prefix "rt";
@@ -100,26 +100,6 @@ module ietf-bfd-opt-auth {
     description
       "When enabled, this implementation supports optimized
        authentication as described in this document.";
-  }
-
-  identity optimized-md5-meticulous-keyed-isaac {
-    base key-chain:crypto-algorithm;
-    description
-      "BFD Optimized Authentication using Meticulous Keyed MD5 as the
-       strong authentication and Meticulous Keyed ISAAC Keyed as the
-       less computationally intensive authentication.";
-    reference
-      "RFC XXXX: Meticulous Keyed ISAAC for BFD Authentication.";
-  }
-
-  identity optimized-sha1-meticulous-keyed-isaac {
-    base key-chain:crypto-algorithm;
-    description
-      "BFD Optimized Authentication using Meticulous Keyed SHA-1 as
-      the strong authentication and Meticulous Keyed ISAAC Keyed as
-      the less computationally intensive authentication.";
-    reference
-      "RFC XXXX: Meticulous Keyed ISAAC for BFD Authentication.";
   }
 
   grouping bfd-opt-auth-config {


### PR DESCRIPTION
Address Acee's comments about removing YANG identities already in secure-sequnce-numbers.  Also, change prefix from bfdoa to bfd-oa to fit style in other documents.