### PR TITLE
Added missing YANG module from secure sequence number draft.

### DIFF
--- a/draft/draft-ietf-bfd-optimizing-authentication.xml
+++ b/draft/draft-ietf-bfd-optimizing-authentication.xml
@@ -140,6 +140,11 @@
 	  at the time of publication.
 	</t>
 
+	<t>
+	  RFC YYYY, where YYYY is the number assigned to <xref
+	  target="I-D.ietf-bfd-secure-sequence-numbers"/>
+	</t>
+
         <t>
 	  YYYY-MM-DD with the actual date of the publication of this
 	  document.

--- a/src/download-dependent-models.py
+++ b/src/download-dependent-models.py
@@ -9,7 +9,8 @@ list_of_ietf_models =\
   ["ietf-tls-client", "draft-ietf-netconf-tls-client-server", "41"],
   ["ietf-tls-common", "draft-ietf-netconf-tls-client-server", "41"],
   ["ietf-tls-server", "draft-ietf-netconf-tls-client-server", "41"],
-  ["ietf-http-client", "draft-ietf-netconf-http-client-server", "20"] ]
+  ["ietf-http-client", "draft-ietf-netconf-http-client-server", "20"],
+  ["ietf-bfd-met-keyed-isaac", "draft-ietf-bfd-secure-sequence-numbers", "26"]]
 
 
 def fetch_and_extract(draft, module, version):

--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -61,7 +61,7 @@ for i in yang/example-*-bfd-config-a.1.*.xml
 do
     name=$(echo $i | cut -f 1-3 -d '.')
     echo "Validating $name.xml"
-    response=`yanglint -ii -t config -p ../bin/yang-parameters -p ../bin ../bin/yang-parameters/iana-if-type@2021-05-17.yang ../bin/iana-bfd-types\@$(date +%Y-%m-%d).yang ../bin/yang-parameters/ietf-bfd-ip-sh@2022-09-22.yang ../bin/yang-parameters/ietf-bfd@2022-09-22.yang ../bin/ietf-bfd-opt-auth\@$(date +%Y-%m-%d).yang $name.xml`
+    response=`yanglint -ii -t config -p ../bin/yang-parameters -p ../bin ../bin/yang-parameters/iana-if-type@2021-05-17.yang ../bin/iana-bfd-types\@$(date +%Y-%m-%d).yang ../bin/yang-parameters/ietf-bfd-ip-sh@2022-09-22.yang ../bin/yang-parameters/ietf-bfd@2022-09-22.yang ../bin/imported-modules/ietf-bfd-met-keyed-isaac@2025-10-08.yang ../bin/ietf-bfd-opt-auth\@$(date +%Y-%m-%d).yang $name.xml`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"

--- a/src/yang/example-ip-sh-bfd-config-a.1.1.xml
+++ b/src/yang/example-ip-sh-bfd-config-a.1.1.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <key-chains
-    xmlns="urn:ietf:params:xml:ns:yang:ietf-key-chain">
+    xmlns="urn:ietf:params:xml:ns:yang:ietf-key-chain"
+    xmlns:opt-auth="urn:ietf:params:xml:ns:yang:ietf-bfd-opt-auth"
+    xmlns:bfd-mki="urn:ietf:params:xml:ns:yang:ietf-bfd-met-keyed-isaac">
   <key-chain>
     <name>bfd-auth-config</name>
     <description>"An example for BFD Optimized Auth configuration."</description>
@@ -16,8 +18,7 @@
           <end-date-time>2017-02-01T00:00:05Z</end-date-time>
         </accept-lifetime>
       </lifetime>
-      <crypto-algorithm xmlns:opt-auth=
-      "urn:ietf:params:xml:ns:yang:ietf-bfd-opt-auth">opt-auth:optimized-sha1-meticulous-keyed-isaac</crypto-algorithm>
+      <crypto-algorithm>bfd-mki:optimized-sha1-meticulous-keyed-isaac</crypto-algorithm>
       <key-string>
         <keystring>testvector</keystring>
       </key-string>
@@ -36,7 +37,8 @@
     xmlns="urn:ietf:params:xml:ns:yang:ietf-routing"
     xmlns:bfd-types="urn:ietf:params:xml:ns:yang:ietf-bfd-types"
     xmlns:iana-bfd-types="urn:ietf:params:xml:ns:yang:iana-bfd-types"
-    xmlns:opt-auth="urn:ietf:params:xml:ns:yang:ietf-bfd-opt-auth">
+    xmlns:opt-auth="urn:ietf:params:xml:ns:yang:ietf-bfd-opt-auth"
+    xmlns:bfd-mki="urn:ietf:params:xml:ns:yang:ietf-bfd-met-keyed-isaac">
   <control-plane-protocols>
     <control-plane-protocol>
       <type>bfd-types:bfdv1</type>

--- a/src/yang/ietf-bfd-opt-auth.yang
+++ b/src/yang/ietf-bfd-opt-auth.yang
@@ -45,10 +45,11 @@ module ietf-bfd-opt-auth {
       Forwarding Detection (BFD).";
   }
 
-  import ietf-key-chain {
-    prefix key-chain;
+  import ietf-bfd-met-keyed-isaac {
+    prefix bfd-mki;
     reference
-      "RFC 8177: YANG Data Model for Key Chains.";
+      "RFC YYYY: Meticulous Keyed ISAAC for BFD Optimized
+                 Authentication.";
   }
 
   organization


### PR DESCRIPTION
Fix issue #79 

The missing YANG module was causing the build/validation of the optimized auth YANG module to fail, which meant it could not be included in the draft.

Note, the side issue of moving the two identities out of the auth module is that now the compiler spits out a warning that the key-chain module is not being used. That is a fix for another day.